### PR TITLE
Fix bug; Remove hide/show dialog

### DIFF
--- a/07-Add-Widgets/Pages/Index.cshtml.cs
+++ b/07-Add-Widgets/Pages/Index.cshtml.cs
@@ -92,6 +92,7 @@ public class IndexModel : PageModel
     }
 
     /* Advanced Layout Dialog */
+
     public async Task<IActionResult> OnPostAdvancedLayoutDialog()
     {
         var layoutRows = new List<LayoutRow>();
@@ -100,8 +101,7 @@ public class IndexModel : PageModel
         var layouts = dashboard.GetCurrentTab().GetLayouts().FirstOrDefault();
         if (layouts != null)
         {
-            // There should ALWAYS be at least one LayoutRow.
-            layoutRows = layouts.LayoutRows.ToList();
+            layoutRows.AddRange(layouts.LayoutRows.ToList());
         }
 
         var layoutTypes = await _service.GetLayoutTypesAsync();

--- a/07-Add-Widgets/wwwroot/src/tuxboard/common.ts
+++ b/07-Add-Widgets/wwwroot/src/tuxboard/common.ts
@@ -72,7 +72,6 @@ export const defaultLayoutRowListSelector = ".row-layout-list";
 export const defaultLayoutRowItemHandleSelector = ".handle";
 export const defaultLayoutRowItemSelector = ".row-layout-item";
 export const defaultLayoutRowPlaceholderSelector = ".placeholder";
-// export const defaultLayoutRowMessageSelector = "#row-layout-message";
 
 export const defaultDeleteRowLayoutButtonSelector = ".row-layout-delete-button";
 export const defaultSaveAdvancedLayoutButtonSelector = ".save-advanced-layout";

--- a/07-Add-Widgets/wwwroot/src/tuxboard/dialog/addWidget/AddWidgetDialog.ts
+++ b/07-Add-Widgets/wwwroot/src/tuxboard/dialog/addWidget/AddWidgetDialog.ts
@@ -6,9 +6,7 @@ export class AddWidgetDialog extends BaseDialog {
 
     allowRefresh: boolean = false;
 
-    constructor(
-        selector: string,
-        private tuxboard: Tuxboard) {
+    constructor(selector: string, private tuxboard: Tuxboard) {
         super(selector);
         this.initialize();
     }
@@ -48,8 +46,8 @@ export class AddWidgetDialog extends BaseDialog {
         })
 
         const addButton = this.getAddWidgetButton();
-        addButton.removeEventListener("click", this.addWidgetToLayout, false);
-        addButton.addEventListener("click", this.addWidgetToLayout, false);
+        addButton?.removeEventListener("click", this.addWidgetToLayout, false);
+        addButton?.addEventListener("click", this.addWidgetToLayout, false);
     }
 
     public listItemOnClick = (item: HTMLLIElement) => {

--- a/07-Add-Widgets/wwwroot/src/tuxboard/dialog/advancedLayout/AdvancedLayoutDialog.ts
+++ b/07-Add-Widgets/wwwroot/src/tuxboard/dialog/advancedLayout/AdvancedLayoutDialog.ts
@@ -37,8 +37,6 @@ export class AdvancedLayoutDialog extends BaseDialog {
     }
 
     getService = () => this.tuxboard.getService();
-    showDialog = () => this.getDialogInstance().show();
-    hideDialog = () => this.getDialogInstance().hide();
 
     public getDropdownTypes          = () => this.getDialog().querySelector(defaultDropdownLayoutTypesSelector);
     public getDropdownItems          = () => this.getLayoutList().querySelectorAll(defaultDropdownLayoutRowTypeSelector);
@@ -91,7 +89,6 @@ export class AdvancedLayoutDialog extends BaseDialog {
 
     private saveLayout = () => {
         const model = this.getLayoutModel();
-
         this.getService().saveAdvancedLayout(model)
             .then((data:string) => {
                 this.tuxboard.updateDashboard(data);

--- a/07-Add-Widgets/wwwroot/src/tuxboard/tuxbar/Tuxbar.ts
+++ b/07-Add-Widgets/wwwroot/src/tuxboard/tuxbar/Tuxbar.ts
@@ -26,12 +26,15 @@ export class Tuxbar {
     }
 
     public initialize = () => {
-        this.controls.push(new TuxbarSpinner(this, defaultTuxbarSpinnerSelector));
         this.controls.push(new RefreshButton(this, defaultTuxbarRefreshButton));
         this.controls.push(new AddWidgetButton(this, defaultAddWidgetButton));
-        this.controls.push(new TuxbarMessage(this, defaultTuxbarMessageSelector));
+
         this.controls.push(new SimpleLayoutButton(this, defaultSimpleLayoutButton));
         this.controls.push(new AdvancedLayoutButton(this, defaultAdvancedLayoutButton));
+
+        this.controls.push(new TuxbarMessage(this, defaultTuxbarMessageSelector));
+
+        this.controls.push(new TuxbarSpinner(this, defaultTuxbarSpinnerSelector));
     }
 }
 


### PR DESCRIPTION
- Adding a Widget causing multiple widgets on the dashboard
When adding a new widget the first time, the new widget is added to the dashboard. On adding another widget (doesn't have to be the same widget), it adds TWO widgets. On adding a widget a third time, the widget is added to the dashboard FOUR times.
The issue was multiple click events on the Add Widget button.

- Removed extra methods from the descendant xxxDialog classes